### PR TITLE
GPHIBERNATEFILTER-2 Filters should behave correctly in class hierarchies...

### DIFF
--- a/src/groovy/org/grails/plugin/hibernate/filter/HibernateFilterBuilder.groovy
+++ b/src/groovy/org/grails/plugin/hibernate/filter/HibernateFilterBuilder.groovy
@@ -75,6 +75,13 @@ class HibernateFilterBuilder {
 			configuration.getCollectionMapping("${domainClass.fullName}.$options.collection") :
 			configuration.getClassMapping(domainClass.fullName)
 
+        if (entity == null && !domainClass.isRoot()) {
+            // No matching entity found and domain class is a subclass.
+            // Filter will be added when found.
+            // TODO: Log a warning since the collection name might have been a typo
+            return
+        }
+
 		// now add the filter to the class or collection
 		entity.addFilter name, condition
 


### PR DESCRIPTION
Burt, Give this a go, I'm not sure it is perfect but it seems to be working for me.

Bail when we don't find the specific entity to add a filter to when
in a class hierarchy. There is an issue that this could hide a
configuration error such as a misspelling.
