### PR TITLE
Use superclass Configuration instead of HibernateFilterDomainConfigurati...

### DIFF
--- a/src/groovy/org/grails/plugin/hibernate/filter/HibernateFilterBuilder.groovy
+++ b/src/groovy/org/grails/plugin/hibernate/filter/HibernateFilterBuilder.groovy
@@ -3,6 +3,7 @@ package org.grails.plugin.hibernate.filter
 import grails.util.Metadata
 
 import org.codehaus.groovy.grails.commons.GrailsDomainClass
+import org.hibernate.cfg.Configuration
 import org.hibernate.cfg.Mappings
 import org.hibernate.engine.FilterDefinition
 import org.hibernate.type.TypeFactory
@@ -18,10 +19,10 @@ class HibernateFilterBuilder {
 	private boolean grails1 = Metadata.current.getGrailsVersion().startsWith('1')
 	private Mappings mappings
 
-	HibernateFilterDomainConfiguration configuration
+    Configuration configuration
 	GrailsDomainClass domainClass
 
-	HibernateFilterBuilder(HibernateFilterDomainConfiguration configuration, GrailsDomainClass domainClass) {
+	HibernateFilterBuilder(Configuration configuration, GrailsDomainClass domainClass) {
 		this.configuration = configuration
 		this.domainClass = domainClass
 		mappings = configuration.createMappings()


### PR DESCRIPTION
...on in HibernateFilterBuilder constructor.  This makes it possible to use a custom configClass - needed for compatibility with envers plugin.  See http://grails.1312388.n4.nabble.com/hibernate-filter-plugin-amp-envers-plugin-Plugin-incompatability-td4474887.html